### PR TITLE
More detailed background links for referencing IPFS

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,8 +38,8 @@
         <p>
           DASL ("dazzle") is a small set of simple, standard primitives to work on content-addressed data.
           We call it "data-addressed" because it supports a data serialization component that makes
-          content-addressing sweet and easy when working with data. The design is taken from the
-          <a href="https://ipfs.tech/">IPFS</a> universe, but simplified so as to improve interoperability,
+          <a href="https://proto.school/content-addressing">content-addressing</a> sweet and easy when working with data. The design is taken from subcomponents of the 
+          <a href="https://docs.ipfs.tech/concepts/content-addressing/">IPFS</a> universe, but simplified to improve interoperability,
           decrease costs, and work well with the web. More specifically, our priorities are:
         </p>
         <ul>


### PR DESCRIPTION
- link to Protoschool for content addressing
- link to CID section of IPFS docs