### PR TITLE
More context for non-IPFS readers

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       <section id="what">
         <h2>What is this?</h2>
         <p>
-          DASL ("dazzle") is a small set of simple, standard primitives for working with data. It builds on content addressing, a proven approach used in Git and <a href="https://docs.ipfs.tech/concepts/what-is-ipfs/">IPFS</a> to create reliable content identifiers (known as CIDs) through cryptographic hashing. Content addressing enables robust data integrity checks and efficient networking: systems can verify they received exactly what they asked for and avoid downloading the same content twice.
+          DASL ("dazzle") is a small set of simple, standard primitives for working with content-addressed, linked data. It builds on content addressing, a proven approach used in Git and <a href="https://docs.ipfs.tech/concepts/what-is-ipfs/">IPFS</a> to create reliable content identifiers (known as CIDs) through cryptographic hashing. Content addressing enables robust data integrity checks and efficient networking: systems can verify they received exactly what they asked for and avoid downloading the same content twice. The linked data part lets you link to stuff by its hash. You can build very big graphs with these primitives, such as the graph behind Bluesky. 
         </p>
         <p>
           We call DASL "data-addressed" because it supports a data serialization component that makes content-addressing sweet and easy when working with data. The design is taken from the <a href="https://ipfs.tech/">IPFS</a> universe, but simplified to improve interoperability, decrease costs, and work well with the web. 

--- a/index.html
+++ b/index.html
@@ -36,11 +36,13 @@
       <section id="what">
         <h2>What is this?</h2>
         <p>
-          DASL ("dazzle") is a small set of simple, standard primitives to work on content-addressed data.
-          We call it "data-addressed" because it supports a data serialization component that makes
-          content-addressing sweet and easy when working with data. The design is taken from the
-          <a href="https://ipfs.tech/">IPFS</a> universe, but simplified so as to improve interoperability,
-          decrease costs, and work well with the web. More specifically, our priorities are:
+          DASL ("dazzle") is a small set of simple, standard primitives for working with data. It builds on content addressing, a proven approach used in Git and <a href="https://docs.ipfs.tech/concepts/what-is-ipfs/">IPFS</a> to create reliable content identifiers (known as CIDs) through cryptographic hashing. Content addressing enables robust data integrity checks and efficient networking: systems can verify they received exactly what they asked for and avoid downloading the same content twice.
+        </p>
+        <p>
+          We call DASL "data-addressed" because it supports a data serialization component that makes content-addressing sweet and easy when working with data. The design is taken from the <a href="https://ipfs.tech/">IPFS</a> universe, but simplified to improve interoperability, decrease costs, and work well with the web. 
+        </p>
+        <p></p>
+          More specifically, our priorities are:
         </p>
         <ul>
           <li>
@@ -80,6 +82,7 @@
           DASL is a strict subset of IPFS CIDs and IPLD, so existing IPFS and IPLD implementations will just
           read DASL without so much as a hiccup. Some implementations also specifically target a DASL subset.
         </p>
+        <p>Here are some implementations that partially or fully support DASL:</p>
         <ul>
           <li>
             <a href="https://github.com/mary-ext/atcute/">atcute</a> (JS/TS): a collection of lightweight
@@ -116,7 +119,7 @@
         <section id="cid">
           <h3>Content IDs (CIDs)</h3>
           <p>
-            DASL CIDs are a strict subset of IPFS CIDs (but you don't need to understanding anything about IPFS to
+            DASL CIDs are a strict subset of <a href="https://docs.ipfs.tech/concepts/content-addressing/">IPFS CIDs</a>a> (but you don't need to understanding anything about IPFS to
             either use or implement them) with the following properties:
           </p>
           <ul>
@@ -176,7 +179,7 @@
               Remove the next two bytes in <var>CID bytes</var> and store them in <var>hash type</var> and <var>hash size</var>,
               respectively.
             </li>
-            <li>If <var>hash type</var> is not equal to <code>0x12</code> (SJA-256) or <code>0x1e</code> (Blake-3), throw an error.</li>
+            <li>If <var>hash type</var> is not equal to <code>0x12</code> (SHA-256) or <code>0x1e</code> (Blake-3), throw an error.</li>
             <li>Store the rest of <var>CID bytes</var> in <code>digest</code>.</li>
             <li>Return <var>version</var>, <var>codec</var>, <var>hash type</var>, <var>hash size</var>, and <var>digest</var></li>
           </ol>
@@ -184,7 +187,7 @@
         <section id="dcbor42">
           <h3>Deterministic CBOR with tag 42 (dCBOR42)</h3>
           <p>
-            dCBOR42 is a subset of IPLD that only supports DAG-CBOR serialization (DAG-JSON can be used for debugging
+            dCBOR42 is a subset of <a href="https://ipld.io/docs/intro/primer/">IPLD</a> that only supports DAG-CBOR serialization (DAG-JSON can be used for debugging
             purposes, but the CIDs embedded in it should be the CIDs that correspond to the CBOR serialization) and
             that uses the IETF's deterministic CBOR encoding rules to guarantee a deterministic output. We support no
             ADLs.


### PR DESCRIPTION
Adds some intro text and a few deeper links into docs, to address (but not fully fix) #6.