### PR TITLE
typofix for closing link tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
         <section id="cid">
           <h3>Content IDs (CIDs)</h3>
           <p>
-            DASL CIDs are a strict subset of <a href="https://docs.ipfs.tech/concepts/content-addressing/">IPFS CIDs</a>a>
+            DASL CIDs are a strict subset of <a href="https://docs.ipfs.tech/concepts/content-addressing/">IPFS CIDs</a>
             (but you don't need to understanding anything about IPFS to either use or implement them) with the following properties:
           </p>
           <ul>


### PR DESCRIPTION
I think I introduced this typo in #10.