### PR TITLE
Replace libipld with ipld-core

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,8 +104,7 @@
             wrapper around Rust, focused on the ATmosphere.
           </li>
           <li>
-            <a href="https://github.com/ipld/libipld">libipld</a> (Rust): fast Rust implementation, extracted
-            from the original <code>ipfs-rust</code> project.
+            <a href="https://github.com/ipld/rust-ipld-core">ipld-cored</a> (Rust): fast Rust implementation.
           </li>
           <li>
             <a href="https://salsa.debian.org/debian/rust_cid_npm">rust_cid_npm</a> (Rust): Fast and tiny rust

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
             wrapper around Rust, focused on the ATmosphere.
           </li>
           <li>
-            <a href="https://github.com/ipld/rust-ipld-core">ipld-cored</a> (Rust): fast Rust implementation.
+            <a href="https://github.com/ipld/rust-ipld-core">ipld-core</a> (Rust): fast Rust implementation.
           </li>
           <li>
             <a href="https://salsa.debian.org/debian/rust_cid_npm">rust_cid_npm</a> (Rust): Fast and tiny rust


### PR DESCRIPTION
The Rust IPLD implementation libipld is going to be deprecated https://github.com/ipld/libipld/pull/198. Use ipld-core instead.