### PR TITLE
MASL: tweaks to atproto Lexicon definition

### DIFF
--- a/masl.src.html
+++ b/masl.src.html
@@ -370,12 +370,9 @@
     "main": {
       "type": "object",
       "properties": {
-        "src": {
-          "type": "string",
-          "format": "cid"
-        },
+        "src": { "type": "cid-link" },
         "resources": {
-          "type": "object"
+          "type": "unknown"
         },
         // HTTP
         "mediaType": { "type": "string" },
@@ -408,12 +405,12 @@
           "type": "array",
           "items": {
             "type": "object",
+            "required": ["src"],
             "properties":{
               "src": { "type": "string" },
               "sizes": { "type": "string" },
               "purpose": { "type": "string" }
-            },
-            "required": ["src"]
+            }
           }
         },
         "id": {
@@ -426,20 +423,20 @@
           "type": "array",
           "items": {
             "type": "object",
+            "required": ["src"],
             "properties":{
               "src": { "type": "string" },
               "sizes": { "type": "string" },
               "label": { "type": "string" },
               "form_factor": {
                 "type": "string",
-                "enum": ["narrow", "wide"]
+                "knownValues": ["narrow", "wide"]
               },
               "platform": {
                 "type": "string",
-                "enum": [""android", "chromeos", "ios", "ipados", "kaios", "macos", "windows", "xbox", "chrome_web_store", "itunes", "microsoft", "microsoft", "play"]
-              },
-            },
-            "required": ["src"]
+                "knownValues": ["android", "chromeos", "ios", "ipados", "kaios", "macos", "windows", "xbox", "chrome_web_store", "itunes", "microsoft", "microsoft", "play"]
+              }
+            }
           }
         },
         "short_name": {
@@ -455,20 +452,10 @@
         },
         "roots": {
           "type": "array",
-          "items": {
-            "type": "string",
-            "format": "cid"
-          }
-        },
-        // AT (specifying this might not be AT compatible)
-        "$type": {
-          "type": "string"
+          "items": { "type": "cid-link" }
         },
         // versioning
-        "prev": {
-          "type": "string",
-          "format": "cid"
-        }
+        "prev": { "type": "cid-link" }
       }
     }
   }


### PR DESCRIPTION
This PR proposes some style/format changes to the atproto Lexicon definition (I should definitely have a style guide to help with authoring Lexicons!):

- for proper tag42 links, use `cid-link` not string with "format: cid"
- string `knownValues` is prefered over enum, for extensibility ("open" not "closed" set)
- the "$type" field should not be defined in the lexicon itself
- "type: unknown" is good for objects with arbitrary keys, and which does not require "$type"
- move "required" lists up above "properties" for easier reading

Didn't include in this PR, but might want to review:

- the "id" field seems under-specified?
- lexicon definition has sub-name "main", but has type "object", not "record". a bit funny, not though necessarily a problem
