### PR TITLE
CAR: remove note about empty CIDs

### DIFF
--- a/car.src.html
+++ b/car.src.html
@@ -95,10 +95,7 @@
           encoded using tag 42 ([[cid]]). A CAR can be used
           to contain one or more DAGs of [[drisl]] content and the purpose of the
           <code>roots</code> is to list one or more roots for those DAGs. The array
-          may be empty if you do not care about encoding DAGs. <strong>NOTE</strong>:
-          Some implementations expect there to always be at least one root. If you do
-         not wish to indicate a root but have to interoperate with those implementations,
-         you can always use the empty DASL CID <code>\x01\x55\x12\x00</code> instead.
+          may be empty if you do not care about encoding DAGs.
         </li>
       </ul>
       <p>


### PR DESCRIPTION
Empty CIDs are not a thing anymore due to
https://github.com/darobin/dasl.ing/commit/904bdbe0177f1dcb2f1f40ad502a16d4644d7ea2. Hence remove the note about them in the CAR spec.