### PR TITLE
Remove in in-body header language

### DIFF
--- a/car.src.html
+++ b/car.src.html
@@ -151,7 +151,7 @@
           result in <var>data</var>.
         </li>
         <li>
-          Return <var>cid</var>, <var>data size</var> and <var>data</var>.
+          Return <var>cid</var>, <var>data size</var>, and <var>data</var>.
         </li>
       </ol>
     </section>


### PR DESCRIPTION
Now a CAR file contains a single header. The body consists of a sequence of blocks, which are length-prefixed. Those blockes are a tuple consisting of the CID and the corresponding data.

---

This change got way less intrusive than I thought.

I'm a bit unsure about the "less than 36 bytes" change, though.