### PR TITLE
Add copy-to-clipboard button and styling

### DIFF
--- a/copy-page.js
+++ b/copy-page.js
@@ -1,0 +1,81 @@
+function getCopyPayload() {
+  const main = document.querySelector('main');
+  if (!main) return null;
+
+  // Use innerText so the clipboard gets readable text (not raw HTML markup).
+  const text = main.innerText.trim();
+
+  return { text };
+}
+
+async function writeToClipboard({ text }) {
+  // Prefer plain text only so pastes are human-readable everywhere.
+  if (navigator.clipboard && navigator.clipboard.write) {
+    const item = new ClipboardItem({
+      'text/plain': new Blob([text], { type: 'text/plain' }),
+    });
+    await navigator.clipboard.write([item]);
+    return;
+  }
+
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.left = '-9999px';
+  ta.style.top = '0';
+  document.body.appendChild(ta);
+  ta.select();
+  document.execCommand('copy');
+  document.body.removeChild(ta);
+}
+
+function setButtonState(btn, { state, message }) {
+  const original = btn.dataset.originalText || btn.textContent;
+  btn.dataset.originalText = original;
+
+  if (state === 'idle') {
+    btn.textContent = original;
+    btn.disabled = false;
+    btn.removeAttribute('aria-busy');
+    return;
+  }
+
+  btn.textContent = message;
+  btn.disabled = true;
+  btn.setAttribute('aria-busy', 'true');
+}
+
+function setupCopyButton() {
+  const btn = document.querySelector('button.copy-page');
+  if (!btn) return;
+
+  btn.addEventListener('click', async () => {
+    const payload = getCopyPayload();
+    if (!payload) return;
+
+    try {
+      setButtonState(btn, { state: 'working', message: 'Copying…' });
+      await writeToClipboard(payload);
+      setButtonState(btn, { state: 'done', message: 'Copied!' });
+      setTimeout(() => setButtonState(btn, { state: 'idle' }), 1200);
+    }
+    catch (err) {
+      console.error('Copy failed:', err);
+      setButtonState(btn, { state: 'error', message: 'Copy failed' });
+      setTimeout(() => setButtonState(btn, { state: 'idle' }), 1600);
+    }
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setupCopyButton);
+}
+else {
+  setupCopyButton();
+}

--- a/sisl.js
+++ b/sisl.js
@@ -100,6 +100,7 @@ class SISL {
       el('meta', { property: 'og:site_name', content: 'DASL' }, [], head);
       el('meta', { property: 'og:locale', content: 'en' }, [], head);
       el('meta', { name: 'theme-color', content: '#00ff75' }, [], head);
+      el('script', { type: 'module', src: 'copy-page.js' }, [], head);
 
       // main & header
       const main = doc.createElement('main');
@@ -143,7 +144,17 @@ class SISL {
       const bk = el('div', { class: 'nav-back' }, [
         'A specification of the ',
         el('a', { href: '/' }, ['DASL Project']),
-        '.'
+        '. ',
+        el(
+          'button',
+          {
+            type: 'button',
+            class: 'copy-page',
+            title: 'Copy this spec to your clipboard',
+            'aria-label': 'Copy this spec to your clipboard',
+          },
+          ['Copy']
+        ),
       ]);
       doc.body.prepend(bk);
       // definitions & xrefs

--- a/spec.css
+++ b/spec.css
@@ -16,6 +16,36 @@ body {
   text-transform: uppercase;
   text-align: right;
 }
+.nav-back .copy-page {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font: inherit;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  margin-left: 1rem;
+  padding: 0.3rem 0.8rem;
+  border: 2px solid #000;
+  background: #fff;
+  color: #000;
+  box-shadow: 2px 2px 0 #000;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background-color 120ms ease;
+}
+.nav-back .copy-page:disabled {
+  opacity: 0.7;
+  cursor: default;
+  box-shadow: 1px 1px 0 #000;
+}
+.nav-back .copy-page:not(:disabled):hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0 #000;
+  background: var(--yellow);
+}
+.nav-back .copy-page:focus-visible {
+  outline: 3px solid var(--purple);
+  outline-offset: 2px;
+}
 main {
   max-width: var(--spec-width);
 }


### PR DESCRIPTION
Adds an auto-generated “Copy” button to each spec page so readers can grab the page content in one click. This makes it easy to hand the spec text to an assistant or paste into a chat without fussing with select-all or clicking and dragging, or *gasp* actually reading it! The button copies a clean, human-readable version (HTML tags stripped) for predictable pastes.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/118cf460-85d1-4a14-bc0f-ea220f692319" />

