### PR TITLE
drisl: exlcude negative

### DIFF
--- a/drisl.src.html
+++ b/drisl.src.html
@@ -56,8 +56,7 @@
               Completely avoiding floating-point numbers is recommended to minimize interoperability and tooling issues.
             </li>
             <li>
-              Even where floating-point numbers are used, most of the IEEE 754 "special" floating points (infinity, negative infinity, minimal NaN, and NaN with payloads) must not be encoded.
-              Negative zero is the only allowed special floating point.
+              Even where floating-point numbers are used, most of the IEEE 754 "special" floating points (infinity, negative infinity, minimal NaN, NaN with payloads and negative zero) must not be encoded.
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Align with [DAG-CBOR](https://github.com/ipld/ipld/pull/380) and [cbor42](https://github.com/ipfs-tech/cbor42/pull/18) and exclude the negative zero float `-0.0` from being encoded.